### PR TITLE
Update modal height to give bottom offset of 10%, just like the top

### DIFF
--- a/src/cdn/elements/modals.css
+++ b/src/cdn/elements/modals.css
@@ -12,7 +12,7 @@
   top: 10%;
   min-width: 320rem;
   max-width: 100%;
-  max-height: 100%;
+  max-height: calc(100vh - 20%);
   overflow-x: hidden;
   overflow-y: auto;
 }
@@ -102,6 +102,7 @@
   bottom: auto;
   width: auto;
   height: 100%;
+  max-height: 100%;
 }
 
 .modal.right {
@@ -112,6 +113,7 @@
   bottom: auto;
   width: auto;
   height: 100%;
+  max-height: 100%;
 }
 
 .modal.bottom {


### PR DESCRIPTION
**Description**
This PR introduces an update to the modal element to avoid the bottom of the modal overflowing the bottom of a users viewport.

We can't simply set bottom to 10%, otherwise all modals will be that full size, no matter how short the content. Using a max-height of 100vh minus the top and bottom offset that we want, allows us to have the modal grow as large as it needs to be, but then not going further than the bottom of the viewport.
This change does have a side effect on the right and left variations of the modal, so that has been corrected by "resetting" the max-height value for those variations

**Preview**
I have deployed the BeerCSS documentation to a Netlify site using my repository (I have added a noindex robots meta tag, so search engines won't point people towards it).

The deployment can be found here (with a link to the modals section, if you're using Chrome):

https://beercss-denno020-preview.netlify.app/#:~:text=videos-,Modals,-code

closes #36 