### PR TITLE
Fix: Make modal overlay's z-index less than modal's z-index

### DIFF
--- a/src/cdn/elements/overlays.css
+++ b/src/cdn/elements/overlays.css
@@ -8,7 +8,7 @@
   height: 100%;
   color: var(--on-background);
   background-color: var(--overlay);
-  z-index: 100;
+  z-index: 95;
   will-change: opacity;
   transition: var(--speed3) all;
 }


### PR DESCRIPTION
In some scenarios, like when you add the overlay after the modal, the modal comes behind the overlay. Making the overlay's z-index less than the modal fixes this issue.

Example: https://codepen.io/devw64/pen/NWXVKXx