### PR TITLE
Fix: Text inside buttons and chips shouldn't be user selectable

### DIFF
--- a/src/cdn/elements/buttons.css
+++ b/src/cdn/elements/buttons.css
@@ -15,6 +15,7 @@ button {
   margin: 0 8rem;
   border-radius: 4rem;
   transition: var(--speed3) transform, var(--speed3) border-radius, var(--speed3) padding;
+  user-select: none;
 }
 
 .button > :not(.dropdown, .progress, .badge, .tooltip) + :not(.dropdown, .progress, .badge, .tooltip),

--- a/src/cdn/elements/chips.css
+++ b/src/cdn/elements/chips.css
@@ -15,6 +15,7 @@
   text-transform: none;
   border-radius: 8rem;
   transition: var(--speed3) transform, var(--speed3) border-radius, var(--speed3) padding;
+  user-select: none;
 }
 
 .chip > :not(.dropdown, .progress, .badge, .tooltip) + :not(.dropdown, .progress, .badge, .tooltip) {


### PR DESCRIPTION
Currently, text inside buttons and chips are selectable. this PR will fix that.

Bug Example: https://codepen.io/kickerbnu/pen/Rwogbpe

See: https://material.io/components/buttons