### PR TITLE
fix: safari expansion indicator

### DIFF
--- a/src/cdn/elements/expansions.css
+++ b/src/cdn/elements/expansions.css
@@ -1,6 +1,10 @@
 summary.none {
   list-style-type: none;
-} 
+}
+
+summary.none::-webkit-details-marker {
+  display: none;
+}
   
 summary {
   cursor: pointer;


### PR DESCRIPTION
This fixes: https://github.com/beercss/beercss/issues/88