### PR TITLE
#12 Update system fonts

### DIFF
--- a/src/cdn/settings/dark.css
+++ b/src/cdn/settings/dark.css
@@ -31,7 +31,7 @@ body.dark {
   --elevate2: 0 0.375rem 0.625rem 0 rgb(0 0 0 / 0.14), 0 0.0625rem 1.125rem 0 rgb(0 0 0 / 0.12), 0 0.1875rem 0.3125rem -0.0625rem rgb(0 0 0 / 0.3);
   --elevate3: 0 0.625rem 1rem 0 rgb(0 0 0 / 0.14), 0 0.0625rem 1.9375rem 0 rgb(0 0 0 / 0.12), 0 0.1875rem 0.5625rem 0 rgb(0 0 0 / 0.4);
   --size: 16px;
-  --font: "Roboto", blinkmacsystemfont, -apple-system, "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+  --font: "Roboto", blinkmacsystemfont, system-ui, "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
   --speed1: 0.1s;
   --speed2: 0.2s;
   --speed3: 0.3s;

--- a/src/cdn/settings/dark.css
+++ b/src/cdn/settings/dark.css
@@ -31,7 +31,7 @@ body.dark {
   --elevate2: 0 0.375rem 0.625rem 0 rgb(0 0 0 / 0.14), 0 0.0625rem 1.125rem 0 rgb(0 0 0 / 0.12), 0 0.1875rem 0.3125rem -0.0625rem rgb(0 0 0 / 0.3);
   --elevate3: 0 0.625rem 1rem 0 rgb(0 0 0 / 0.14), 0 0.0625rem 1.9375rem 0 rgb(0 0 0 / 0.12), 0 0.1875rem 0.5625rem 0 rgb(0 0 0 / 0.4);
   --size: 16px;
-  --font: "Roboto", blinkmacsystemfont, system-ui, "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+  --font: "Roboto", system-ui, "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
   --speed1: 0.1s;
   --speed2: 0.2s;
   --speed3: 0.3s;

--- a/src/cdn/settings/light.css
+++ b/src/cdn/settings/light.css
@@ -32,7 +32,7 @@ body.light {
   --elevate2: 0 0.375rem 0.625rem 0 rgb(0 0 0 / 0.14), 0 0.0625rem 1.125rem 0 rgb(0 0 0 / 0.12), 0 0.1875rem 0.3125rem -0.0625rem rgb(0 0 0 / 0.3);
   --elevate3: 0 0.625rem 1rem 0 rgb(0 0 0 / 0.14), 0 0.0625rem 1.9375rem 0 rgb(0 0 0 / 0.12), 0 0.1875rem 0.5625rem 0 rgb(0 0 0 / 0.4);
   --size: 16px;
-  --font: "Roboto", blinkmacsystemfont, -apple-system, "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+  --font: "Roboto", blinkmacsystemfont, system-ui, "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
   --speed1: 0.1s;
   --speed2: 0.2s;
   --speed3: 0.3s;

--- a/src/cdn/settings/light.css
+++ b/src/cdn/settings/light.css
@@ -32,7 +32,7 @@ body.light {
   --elevate2: 0 0.375rem 0.625rem 0 rgb(0 0 0 / 0.14), 0 0.0625rem 1.125rem 0 rgb(0 0 0 / 0.12), 0 0.1875rem 0.3125rem -0.0625rem rgb(0 0 0 / 0.3);
   --elevate3: 0 0.625rem 1rem 0 rgb(0 0 0 / 0.14), 0 0.0625rem 1.9375rem 0 rgb(0 0 0 / 0.12), 0 0.1875rem 0.5625rem 0 rgb(0 0 0 / 0.4);
   --size: 16px;
-  --font: "Roboto", blinkmacsystemfont, system-ui, "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+  --font: "Roboto", system-ui, "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
   --speed1: 0.1s;
   --speed2: 0.2s;
   --speed3: 0.3s;


### PR DESCRIPTION
replace `-apple-system` and `blinkmacsystemfont` with `system-ui` to keep up with browser trends.