### PR TITLE
Fix `--grid-gap` in .grid.no-space to not be unitless, to fix no-space grid layout

### DIFF
--- a/src/cdn/elements/grids.css
+++ b/src/cdn/elements/grids.css
@@ -11,7 +11,7 @@
 }
 
 .grid.no-space {
-  --grid-gap: 0;
+  --grid-gap: 0rem;
 }
 
 .grid.medium-space {


### PR DESCRIPTION
`--grid-gap` must have a unit for `calc()` involving said variable to work.

From https://drafts.csswg.org/css-values/#calc-type-checking:
> **NOTE**: Because `<number-token>`s are always interpreted as `<number>`s or `<integer>`s, "unitless 0" `<length>`s aren't supported in math functions. That is, `width: calc(0 + 5px);` is invalid, because it's trying to add a `<number>` to a `<length>`, even though both `width: 0;` and `width: 5px;` are valid.

This particular issue took me a few hours to figure out (my grid was behaving *very* oddly in various ways).
A tell-tale symptom is that grid cells won't be the same width even if they're all (say) `s4`. The widths will change more or less dynamically, since the cell width calculation (which involves `var(--grid-gap)`) will be ignored due to an invalid value.

**Bug reproduction** (if needed): Make a `<div class="grid no-space">...</div>` element, and fill it with members/cells of non-equal desired size (e.g. put a button in one, icon in another, and `-` in a third).
Can also try a non-full line (e.g. `<div class="s4"/><div class="s4"/>`).