### PR TITLE
Labels working properly for 'datetime-local' input

### DIFF
--- a/src/cdn/beer.ts
+++ b/src/cdn/beer.ts
@@ -110,7 +110,7 @@ export default (() => {
     const parentTarget = parent(target);
     const label = query("label", parentTarget) as HTMLLabelElement;
     const isBorder = hasClass(parentTarget, "border") && !hasClass(parentTarget, "fill");
-    const toActive = document.activeElement === target || input.value || query("[selected]", input) || hasType(input, "date") || hasType(input, "time");
+    const toActive = document.activeElement === target || input.value || query("[selected]", input) || hasType(input, "date") || hasType(input, "time") || hasType(input, "datetime-local");
 
     if (toActive) {
       if (isBorder && label) {


### PR DESCRIPTION
['datetime-local' input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local) is a way of inputting date and time using one single input element. The labels for these elements require to be active all the time, like it happens with 'date' and 'time' input types.
This used to work in old versions of beercss (for example, in v2.3.0).