### PR TITLE
Typo: removed duplicate semicolon (breaking PostCSS)

### DIFF
--- a/src/cdn/elements/fields.css
+++ b/src/cdn/elements/fields.css
@@ -427,7 +427,7 @@ input[type=search]::-webkit-search-results-decoration {
 
 .field.label > label > a > :is(i, img, svg) {
   height: 1rem;
-  line-height: 1rem;;
+  line-height: 1rem;
   width: 1rem;
   font-size: 1rem;
 }


### PR DESCRIPTION
A duplicate semicolon was breaking my PostCSS plugin in Vite.