### PR TITLE
use relative path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ You can use this html to setup your project. See on [Codepen](https://codepen.io
         <div>More</div>
       </a>
     </nav>
-    
+
     <nav class="bottom s">
       <a>
         <i>home</i>
@@ -219,7 +219,7 @@ You can use this html to setup your project. See on [Codepen](https://codepen.io
         <i>more_vert</i>
       </a>
     </nav>
-    
+
     <main class="responsive">
       <img src="https://www.beercss.com/beer-and-woman.jpg" class="responsive round">
       <h3>Welcome</h3>
@@ -235,7 +235,7 @@ You can use this html to setup your project. See on [Codepen](https://codepen.io
 
 Complete documentation and examples available at:
 
-- **[Documentation](https://github.com/beercss/beercss/blob/main/docs/INDEX.md)**
+- **[Documentation](docs/INDEX.md)**
 - **[Codepen](https://codepen.io/collection/XydYMB)**
 - **[Homepage](https://www.beercss.com)**
 
@@ -243,7 +243,7 @@ Complete documentation and examples available at:
 
 Hi! We are really excited that you are interested in contributing to Beer CSS! Before submitting your contribution, please make sure to take a moment and read through the following guidelines:
 
-https://github.com/beercss/beercss/blob/main/CONTRIBUTING.md
+[Beer CSS Contributing Guidelines](CONTRIBUTING.md)
 
 ## License
 


### PR DESCRIPTION
When I opened the README.md file in VS Code markdown preview, and clicked on the contributing guidelines link, instead of opening the guidelines right there in VS Code, it opened up a new browser window and navigated to the github url. If the link was provided via a relative path, then the contributing guidelines would open in a VS Code tab and prevent navigation away from it. Those who want to view the guidelines in the browser can go directly to github.com.