### PR TITLE
Fix minor `<checkbox>` doc error

### DIFF
--- a/src/home/checkboxes.vue
+++ b/src/home/checkboxes.vue
@@ -22,6 +22,7 @@
             span Disabled
           label.checkbox
             input(type="checkbox", checked, disabled)
+            span Disabled
     .s12
       h6 Checkbox with icons
       .field.middle-align#checkboxes1


### PR DESCRIPTION
Current an example in `<checkbox>` doc misses a `<span>` element.

![image](https://github.com/beercss/beercss/assets/13001378/cd1f0a56-7aa0-4d55-b693-079d7ff5f556)
