### PR TITLE
Fix minor `<checkbox>` doc error

### DIFF
--- a/src/cdn/helpers/dividers.css
+++ b/src/cdn/helpers/dividers.css
@@ -19,3 +19,45 @@
 .small-divider {
   margin: 0.5rem 0 !important;
 }
+
+.horizontal:is(.divider) {
+  inline-size: 0.8em !important;
+  block-size: 0.125rem !important;
+  writing-mode: vertical-lr !important;
+}
+
+.no-line .horizontal {
+  inline-size: 1rem !important;
+}
+
+.tiny-line .horizontal {
+  inline-size: 1.25rem !important;
+}
+
+.small-line .horizontal {
+  inline-size: 1.5rem !important;
+}
+
+.medium-line .horizontal {
+  inline-size: 1.75rem !important;
+}
+
+.large-line .horizontal {
+  inline-size: 2rem !important;
+}
+
+.extra-line .horizontal {
+  inline-size: 2.25rem !important;
+}
+
+.horizontal:is(.small-height) {
+  inline-size: 12rem !important;
+}
+
+.horizontal:is(.medium-height) {
+  inline-size: 24rem !important;
+}
+
+.horizontal:is(.large-height) {
+  inline-size: 36rem !important;
+}

--- a/src/home/checkboxes.vue
+++ b/src/home/checkboxes.vue
@@ -22,6 +22,7 @@
             span Disabled
           label.checkbox
             input(type="checkbox", checked, disabled)
+            span Disabled
     .s12
       h6 Checkbox with icons
       .field.middle-align#checkboxes1

--- a/src/home/page.vue
+++ b/src/home/page.vue
@@ -216,6 +216,10 @@ div
       span Codepen
 
   .responsive.center-align.yellow4
+    nav.row.primary-container.white-text.center-align.no-space.no-margin.no-padding
+      div.max max1
+      div.divider.horizontal.white-border.white.white-text
+      div.min min1
     div.black-text
       .large-height.no-scroll.middle-align.center-align
         img#logo(:src="'/logo.png'", @click="domain.addHomeScreen()")


### PR DESCRIPTION
An example in `<checkbox>` doc misses a `<span>` element.
(And sorry for creating those previous PRs which were pushing to wrong branches/with wrong commits)

![image](https://github.com/beercss/beercss/assets/13001378/cd1f0a56-7aa0-4d55-b693-079d7ff5f556)

