### PR TITLE
More resonsive helpers related to viewport height

### DIFF
--- a/src/cdn/helpers/responsive.css
+++ b/src/cdn/helpers/responsive.css
@@ -26,3 +26,27 @@
     display: none;
   }
 }
+
+@media only screen and (max-height: 12rem) {
+  .mh:not(.sh),
+  .lh:not(.sh),
+  .mh.lh:not(.sh) {
+    display: none;
+  }
+}
+
+@media only screen and (min-height: 12rem) and (max-height: 24rem) {
+  .sh:not(.mh),
+  .lh:not(.mh),
+  .sh.lh:not(.mh) {
+    display: none;
+  }
+}
+
+@media only screen and (min-height: 24rem) {
+  .mh:not(.lh),
+  .sh:not(.lh),
+  .mh.sh:not(.lh) {
+    display: none;
+  }
+}


### PR DESCRIPTION
I mixed `.s`, `.m`, `.l` helpers and `.*-height` helpers into `.*h` helpers.

### Use case

```vue
<template>

<div class="overlay" :class="modalClass" @click="isModalOpen = false">
<dialog class="bottom small-height" :class="modalClass">
  <div class="row">
    <div class="max">
      <!-- modal main content -->
    </div>
    <div class="min sh">
      <button class="circle transparent" @click="isModalOpen = false">
        <i>close</i>
      </button>
    </div>
  </div>
</dialog>

</template>

<script>
const { ref, computed } = import 'vue'

const isModalOpen = ref(true)
const modalClass = computed(() => isModalOpen.value ? 'active' : '')
</script>
```

For this dialog with fixed height, when viewport size is higher than `.small-height`, clicking `.overlay` element would be the default way to close dialog. If viewport getting smaller than `.small-height`, `.overlay` element is no longer accessible and we may hope to have a `close` button. Then `.sh` helper can help.

As far as I remember, very few CSS lib would care height of viewport or even give responsive helpers to deal with it. How do you think of that?
