### PR TITLE
add Noto as a fallback font

### DIFF
--- a/src/cdn/settings/globals.css
+++ b/src/cdn/settings/globals.css
@@ -1,6 +1,6 @@
 :root {
   --size: 16px;
-  --font: Inter, Roboto, "Helvetica Neue", "Arial Nova", "Nimbus Sans", Arial, sans-serif;
+  --font: Inter, Roboto, "Helvetica Neue", "Arial Nova", "Nimbus Sans", Noto Sans, Arial, sans-serif;
   --font-icon: "Material Symbols Outlined";
   --speed1: 0.1s;
   --speed2: 0.2s;


### PR DESCRIPTION
- On many systems, such as Linux, the only font in this stack that works is Arial.
- Arial is a font that looks generic, small, and hard to read
- This adds Noto as a fallback. Noto is a font that's closer to Roboto and [performs extremely well for reading](https://thereadabilityconsortium.org/wp-content/uploads/2023/07/Accelerating_Adult_Readers_with_Typeface_A_Study_of_Individual_Preferences_and_Effectiveness.pdf).