### PR TITLE
explicitly set cursor on text field

### DIFF
--- a/src/cdn/elements/fields.css
+++ b/src/cdn/elements/fields.css
@@ -120,6 +120,7 @@
   background: none;
   resize: none;
   text-align: start;
+  cursor: text;
 }
 
 input::-webkit-date-and-time-value {


### PR DESCRIPTION
- In Firefox, for some reason, setting `all: unset` reset the cursor... but only on the outside of the text field
- This PR explicitly sets `cursor: text` so all of the text field has the correct cursor