### PR TITLE
feat(index): permit importing CSS without build tool

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import "./dist/cdn/beer.min.css";
+import styles from "./dist/cdn/beer.min.css" with { type: "css" };
+document.adoptedStyleSheets.push(styles);
 import { ui } from "./dist/cdn/beer.min.js";
 export {
   ui as default,


### PR DESCRIPTION
Without this change, a build tool is needed to interpret the bare import as a CSS import.  With this change, no build tool is needed in Chrome and Edge in version 93.  Support in Firefox and Safari is not yet available. Implementation progress can be tracked at the Gecko bug and WebKit bug, respectively.

https://bugzilla.mozilla.org/show_bug.cgi?id=1720570 https://bugs.webkit.org/show_bug.cgi?id=227967

See https://fullystacked.net/import-attributes/ and https://web.dev/articles/css-module-scripts for more detailed explanations.