### PR TITLE
fix: hide .min nav on small screens (<992px) fix #453

### DIFF
--- a/src/cdn/elements/navigations.css
+++ b/src/cdn/elements/navigations.css
@@ -35,10 +35,6 @@ nav > :is(ol, ul) > li > :only-child {
   flex: none;
 }
 
-:is(nav, .row).min {
-  display: inline-flex;
-}
-
 :is(nav, .row, li).no-space {
   gap: 0;
 }
@@ -379,5 +375,11 @@ nav.group > :is(.button, button):not(.chip).active {
   nav.top,
   nav.bottom {
     justify-content: space-around;
+  }
+}
+
+@media only screen and (min-width: 993px) {
+    :is(nav, .row).min {
+    display: inline-flex;
   }
 }


### PR DESCRIPTION
### Description: 
This PR fixes an issue where nav.min remains visible on screens smaller than 992px, whereas it is expected to be hidden for proper responsive behavior.

### Details:
- Added a media query for min-width: 993px to scope the .min class visibility appropriately.
- Affects only src/css/navigations.css.

### Testing:
- Verified that the .min nav is now hidden on screens under 992px.
- `npm run test` passes successfully.

Let me know if you prefer a different approach.