### PR TITLE
Update directionality for input elements to work with RTL (fix #545)

### DIFF
--- a/src/cdn/elements/selections.css
+++ b/src/cdn/elements/selections.css
@@ -3,7 +3,6 @@
 .radio,
 .switch {
   --_size: 1.5rem;
-  direction: ltr;
   inline-size: auto;
   block-size: auto;
   line-height: normal;
@@ -46,6 +45,13 @@
 
 :is(.checkbox, .radio) > span:not(:empty) {
   padding-inline-start: 0.25rem;
+}
+
+[dir=rtl] :is(.checkbox, .radio, .switch) > span::before,
+[dir=rtl] :is(.checkbox, .radio, .switch) > span > i,
+[dir=rtl] :is(.checkbox, .radio) > span::after {
+  --_size: inherit;
+  inset: auto calc(var(--_size) * -1) auto auto;
 }
 
 :is(.checkbox, .radio, .switch) > span::before,


### PR DESCRIPTION
This commit solves the issue in #545 by removing the forced `direction: ltr;` for inputs and having different inset for the ::before and ::after pseudo-elements for the relevant input elements when in RTL mode. Please note that as per MDN, the inset property is physical and not logical, therefore the default way of doing inset for inputs (`inset: auto auto auto calc(var(--_size) * -1);`) was forcing the inset to the left. I tried using the logical properties `inset-inline` but it still did not work, so I used a new rule with [dir=rtl].