### PR TITLE
Remove unnecessary `text-transform: none` property from badges and chips

### DIFF
--- a/src/cdn/elements/badges.css
+++ b/src/cdn/elements/badges.css
@@ -6,7 +6,6 @@
   justify-content: center;
   position: absolute;
   font-size: 0.6875rem;
-  text-transform: none;
   z-index: 2;
   padding: 0 0.25rem;
   min-block-size: 1rem;

--- a/src/cdn/elements/chips.css
+++ b/src/cdn/elements/chips.css
@@ -13,7 +13,6 @@
   border: 0.0625rem solid var(--outline-variant);
   color: var(--on-surface-variant);
   padding: 0 var(--_padding);
-  text-transform: none;
   border-radius: 0.5rem;
   transition: transform var(--speed3), border-radius var(--speed3), padding var(--speed3);
   user-select: none;


### PR DESCRIPTION
Quick little PR to propose removing this property from the `.badge` and `.chip` classes. It does not seem necessary, and prevents the usage of text transform helpers like `.upper`, `.lower` and `.capitalize`. These can be quite useful in badges and chips, in my opinion.

An alternative would be to give the `.upper`, `.lower` and `.capitalize` classes a `!important`, but I'd rather remove code than add code. And since I can't find any proper reason for this property I went for this approach.
I am open to discussion, obviously.