### PR TITLE
add touch-action: none to slider inputs for Safari iOS (fix #549)

### DIFF
--- a/src/cdn/elements/sliders.css
+++ b/src/cdn/elements/sliders.css
@@ -50,6 +50,7 @@
   padding: 0;
   margin: 0;
   transform: rotate(0deg);
+  touch-action: none;
 }
 
 .slider > input:only-of-type {


### PR DESCRIPTION
## Summary
- iOS Safari's default pan gesture intercepts touch events before range inputs can handle them, making sliders unusable on phones
- Added `touch-action: none` to `.slider > input` so the browser delegates touch handling to the element

## Test plan
- [ ] Verify sliders are draggable on Safari iOS (iPhone/iPad)
- [ ] Verify sliders still work normally on desktop browsers
- [ ] Verify dual-range sliders still function correctly

Fixes #549