### PR TITLE
Fix .no-opacity and .opacity having swapped values (fix #440)

### DIFF
--- a/src/cdn/helpers/opacities.css
+++ b/src/cdn/helpers/opacities.css
@@ -1,9 +1,9 @@
 .no-opacity {
-  opacity: 1 !important;
+  opacity: 0 !important;
 }
 
 .opacity {
-  opacity: 0 !important;
+  opacity: 1 !important;
 }
 
 .small-opacity {


### PR DESCRIPTION
## Summary
- Swaps `.no-opacity` (now `opacity: 0`) and `.opacity` (now `opacity: 1`) so the naming matches the convention used by other `no-*` helpers (`.no-round` → `border-radius: 0`, `.no-border` → `border-color: transparent`)
- Previously `.no-opacity` set `opacity: 1` which is counter-intuitive — "no opacity" should mean invisible

## Test plan
- [x] `npm run test` passes
- [ ] Verify `.no-opacity` makes elements invisible
- [ ] Verify `.opacity` makes elements fully visible

Fixes #440