### PR TITLE
Fix blur on button clips tooltip (fix #518)

### DIFF
--- a/src/cdn/helpers/blurs.css
+++ b/src/cdn/helpers/blurs.css
@@ -19,3 +19,8 @@
 .large-blur {
   ---blur: 1.5rem;
 }
+
+[class*=blur]:has(> .tooltip) {
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}


### PR DESCRIPTION
## Summary
- `backdrop-filter` creates a new containing block and compositing layer, which clips absolutely-positioned tooltips within blur elements
- Adds a rule to disable `backdrop-filter` when a `.tooltip` is a direct child of a blur element, so the tooltip renders without clipping
- The background-color overlay is preserved — only the blur filter is removed in this case

## Test plan
- [x] `npm run test` passes
- [ ] Verify tooltips on blur buttons render correctly without being clipped
- [ ] Verify blur still works normally on elements without tooltip children

Fixes #518