### PR TITLE
Bump project dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,21 +13,21 @@
     "llms": "node ./build/llms.js"
   },
   "devDependencies": {
-    "@types/jsdom": "^21.1.7",
+    "@types/jsdom": "^28.0.1",
     "@vitejs/plugin-vue": "^5.0.5",
     "@vitest/coverage-v8": "^3.2.4",
-    "@vue/language-plugin-pug": "^2.2.10",
+    "@vue/language-plugin-pug": "^3.2.7",
     "brotli-size": "^4.0.0",
-    "cssnano": "^7.1.1",
-    "fs-extra": "^11.2.0",
-    "jsdom": "^24.1.3",
-    "postcss": "^8.4.38",
-    "pug": "^3.0.3",
-    "typescript": "^5.4.5",
+    "cssnano": "^7.1.7",
+    "fs-extra": "^11.3.4",
+    "jsdom": "^29.0.2",
+    "postcss": "^8.5.12",
+    "pug": "^3.0.4",
+    "typescript": "^6.0.3",
     "vite": "^6.2.3",
     "vitest": "^3.0.9",
-    "vue": "^3.4.27",
-    "vue-tsc": "^2.0.19"
+    "vue": "^3.5.33",
+    "vue-tsc": "^3.2.7"
   },
   "files": [
     "custom-element",


### PR DESCRIPTION
Bumped project dependencies in `package.json`. Major updates include Vue 3.5.33, TypeScript 6.0.3, and jsdom 29.0.2. Vite-related packages were intentionally excluded from this bump to prevent build regressions. Verified that all tests pass and the build remains stable. Distribution files were excluded from the commit as per instructions.

---
*PR created automatically by Jules for task [6078319245569250499](https://jules.google.com/task/6078319245569250499) started by @leonardorafael*