### PR TITLE
fix(field): support dir="rtl" on the field element + preserve :dir() in the CDN build

### DIFF
--- a/build/minified.js
+++ b/build/minified.js
@@ -15,6 +15,10 @@ export default async function() {
         },
       },
       build: {
+        // Minify CSS with cssnano (via postcss) only. esbuild's CSS minifier
+        // lowers :dir() to a :lang() approximation, which is incorrect for
+        // direction-based selectors; cssnano preserves :dir().
+        cssMinify: false,
         esbuild: {
           legalComments: 'none'
         },
@@ -35,7 +39,7 @@ export default async function() {
         },
       },
     });
-    
+
     const cssContent = fs.readFileSync("./dist/cdn/beer.min.css", "utf-8");
     fs.writeFileSync("./dist/cdn/beer.min.css", cssContent.replace(/url\(\//g, "url("));
   } catch (error) {

--- a/src/cdn/elements/fields.css
+++ b/src/cdn/elements/fields.css
@@ -76,12 +76,12 @@
 }
 
 .field > :is(i, img, svg, progress.circle, a),
-[dir=rtl] .field > :is(i, img, svg, progress.circle, a):first-child {
+.field:dir(rtl) > :is(i, img, svg, progress.circle, a):first-child {
   inset: calc(var(--_middle, 0) - 0.75rem) 1rem auto auto;
 }
 
 .field > :is(i, img, svg, progress.circle, a):first-child,
-[dir=rtl] .field > :is(i, img, svg, progress.circle, a) {
+.field:dir(rtl) > :is(i, img, svg, progress.circle, a) {
   inset: calc(var(--_middle, 0) - 0.75rem) auto auto 1rem;
 }
 
@@ -308,7 +308,7 @@ input[type=number] {
   pointer-events: none;
 }
 
-[dir=rtl] .field.label > label {
+.field.label:dir(rtl) > label {
   inset: -0.5rem calc(var(--_start) - 0.0625rem) 0 0.9375rem;
 }
 
@@ -316,7 +316,7 @@ input[type=number] {
   inset: -0.5rem 1.9375rem 0 var(--_start);
 }
 
-[dir=rtl] .field.label[class*=round] > label {
+.field.label[class*=round]:dir(rtl) > label {
   inset: -0.5rem var(--_start) 0 1.9375rem;
 }
 
@@ -363,8 +363,8 @@ input[type=number] {
   clip-path: polygon(-2% -2%, 0.75rem -2%, 0.75rem 0.5rem, calc(100% - 1rem) 0.5rem, calc(100% - 1rem) -2%, 102% -2%, 102% 102%, -2% 102%);
 }
 
-[dir=rtl] .field.label.border:not(.fill) > :is(input, textarea):is(:focus, [placeholder]:not(:placeholder-shown), .active),
-[dir=rtl] .field.label.border:not(.fill) > select {
+.field.label.border:not(.fill):dir(rtl) > :is(input, textarea):is(:focus, [placeholder]:not(:placeholder-shown), .active),
+.field.label.border:not(.fill):dir(rtl) > select {
   clip-path: polygon(-2% -2%, 1rem -2%, 1rem 0.5rem, calc(100% - 0.75rem) 0.5rem, calc(100% - 0.75rem) -2%, 102% -2%, 102% 102%, -2% 102%);
 }
 
@@ -373,8 +373,8 @@ input[type=number] {
   clip-path: polygon(-2% -2%, 1.25rem -2%, 1.25rem 0.5rem, calc(100% - 2rem) 0.5rem, calc(100% - 2rem) -2%, 102% -2%, 102% 102%, -2% 102%);
 }
 
-[dir=rtl] .field.label.border[class*=round]:not(.fill) > :is(input, textarea):is(:focus, [placeholder]:not(:placeholder-shown), .active),
-[dir=rtl] .field.label.border[class*=round]:not(.fill) > select {
+.field.label.border[class*=round]:not(.fill):dir(rtl) > :is(input, textarea):is(:focus, [placeholder]:not(:placeholder-shown), .active),
+.field.label.border[class*=round]:not(.fill):dir(rtl) > select {
   clip-path: polygon(-2% -2%, 2rem -2%, 2rem 0.5rem, calc(100% - 1.25rem) 0.5rem, calc(100% - 1.25rem) -2%, 102% -2%, 102% 102%, -2% 102%);
 }
 


### PR DESCRIPTION
## Summary

Two related changes that make `dir="rtl"` work when set directly on a `.field` element (not only on an ancestor), via the `:dir()` pseudo-class.

### fix(field): use `:dir(rtl)` for the RTL field rules — Fixes #631

The RTL field rules used the descendant combinator `[dir=rtl] .field`, so the RTL notch, label and icon positioning only applied when `dir="rtl"` was on an ancestor. Setting `dir` directly on the `.field` (e.g. to flip a single field without affecting the rest of the page) left the LTR geometry in place while the text ran RTL, breaking the outlined field's border. These selectors now use `:dir(rtl)`, which matches by the element's resolved direction regardless of where `dir` is set (the field itself, an ancestor, or `dir=auto`). A field explicitly set to `dir="ltr"` inside an RTL container also correctly stays LTR.

### build(cdn): minify CSS with cssnano to preserve `:dir()` — Fixes #632

The CDN CSS was minified by esbuild, whose minifier lowers `:dir()` to a `:lang()` approximation (matching by content language, not direction), which would silently break the fix above. `cssnano` (already in the postcss step, and used by the scoped build) preserves `:dir()`, and `:dir()` is now supported across all current browsers, so the lowering is unnecessary. Setting `build.cssMinify: false` minifies the CDN CSS with cssnano only; `:dir()` is preserved and the minified output is slightly smaller.

## Testing

- `npm run test` — all 224 tests pass.
- Verified in the minified `beer.min.css` via computed `clip-path`: `dir` on the field → RTL, `dir` on an ancestor → RTL, plain → LTR, and an explicit `dir="ltr"` field inside an RTL container → LTR.
- `:dir()` is preserved in `beer.min.css` (no `:lang()` rewrite); minified size is slightly smaller.
